### PR TITLE
Add ufbt-based package test pipeline

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -7,16 +7,17 @@ This repo uses uFBT for a mainstream Flipper app workflow.
 - `pip install --upgrade ufbt` (or use the included `venv`)
 
 ## Build & Test (local)
-1. Open a terminal in `apps/mouse-jiggler/fap`
-2. Install toolchain files:
-   - `ufbt vscode_dist`
-3. Lint & format:
-   - `ufbt lint`
-   - `ufbt format`
-4. Build:
-   - `ufbt build`
-5. Optional: Launch to device over USB:
-   - `ufbt launch`
+The repository includes an automated pipeline that runs static checks and
+compiles every app without requiring a physical Flipper device.
+
+1. Ensure the `ufbt` CLI is installed (`pip install ufbt`) or activate the
+   project's virtual environment.
+2. From the repository root, run one of the helper targets:
+   - `make lint` – run `ufbt lint` for every app.
+   - `make build-all` – compile all apps (`ufbt build`).
+   - `make test` – execute lint + build in sequence (recommended for PRs).
+3. Optional: for manual device validation after the pipeline passes, launch to
+   the Flipper over USB from an individual app directory with `ufbt launch`.
 
 ## Pull Requests
 - CI builds for dev & release and runs `ufbt lint`.

--- a/Makefile
+++ b/Makefile
@@ -1,50 +1,22 @@
-# Mouse and keyboard Jiggler - Flipper Zero Application
-# Build instructions for Flipper Zero firmware
+# Unified test pipeline for all Flipper packages.
 
-APP_NAME = mousejiggler
-APP_DIR = applications/external/$(APP_NAME)
-
-.PHONY: build install clean help
+.PHONY: help lint build-all test
 
 help:
-	@echo "Mouse and keyboard Jiggler - Build Commands"
-	@echo "=================================="
-	@echo "build   - Build the application (.fap file)"
-	@echo "install - Copy files to Flipper firmware directory"
-	@echo "clean   - Clean build artifacts"
-	@echo "help    - Show this help message"
+	@echo "Flipper Collection Build Commands"
+	@echo "================================="
+	@echo "make lint       - Run ufbt lint for every app"
+	@echo "make build-all  - Build all apps without using hardware"
+	@echo "make test       - Lint and build all apps"
 	@echo ""
-	@echo "Prerequisites:"
-	@echo "- Flipper Zero firmware source code"
-	@echo "- Set FLIPPER_FW_PATH environment variable"
+	@echo "These commands rely on ufbt being available in your PATH."
+	@echo "Install it with 'pip install ufbt' or by activating the repo's venv."
 
-build:
-	@if [ -z "$(FLIPPER_FW_PATH)" ]; then \
-		echo "Error: FLIPPER_FW_PATH environment variable not set"; \
-		echo "Please set it to your Flipper Zero firmware directory"; \
-		exit 1; \
-	fi
-	cd $(FLIPPER_FW_PATH) && ./fbt fap_$(APP_NAME)
+lint:
+	python3 scripts/run_package_checks.py --skip-build
 
-install:
-	@if [ -z "$(FLIPPER_FW_PATH)" ]; then \
-		echo "Error: FLIPPER_FW_PATH environment variable not set"; \
-		exit 1; \
-	fi
-	@echo "Installing source files to firmware directory..."
-	mkdir -p $(FLIPPER_FW_PATH)/$(APP_DIR)
-	cp mousejiggler.c $(FLIPPER_FW_PATH)/$(APP_DIR)/
-	cp application.fam $(FLIPPER_FW_PATH)/$(APP_DIR)/
-	cp -r icons $(FLIPPER_FW_PATH)/$(APP_DIR)/ 2>/dev/null || true
-	@echo "Files installed successfully!"
-	@echo "Now run: make build"
+build-all:
+	python3 scripts/run_package_checks.py --skip-lint
 
-clean:
-	@if [ -n "$(FLIPPER_FW_PATH)" ]; then \
-		cd $(FLIPPER_FW_PATH) && ./fbt fap_$(APP_NAME) --clean; \
-	fi
-	@echo "Clean completed!"
-
-# Quick build and install
-all: install build
-	@echo "Build completed! Check $(FLIPPER_FW_PATH)/dist/ for the .fap file"
+test:
+	python3 scripts/run_package_checks.py

--- a/README.md
+++ b/README.md
@@ -15,4 +15,5 @@ A curated collection of Flipper Zero apps.
 - BadUSB: packages/badusb/
 - NFC: packages/nfc/
 
-See DEVELOPMENT.md for the build/test workflow.
+See DEVELOPMENT.md for the build/test workflow. A hardware-free validation
+pipeline is provided via ``make test``.

--- a/scripts/run_package_checks.py
+++ b/scripts/run_package_checks.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Utilities to verify Flipper packages without hardware.
+
+This script provides a repeatable pipeline for checking that each app in the
+repository builds cleanly using ``ufbt``.  It replaces the ad-hoc process of
+copying sources into the firmware tree and loading them on-device, enabling
+local verification with just the toolchain.
+
+Steps performed for every ``apps/*/fap`` directory:
+
+1. ``ufbt lint`` – style and static analysis checks.
+2. ``ufbt build`` – compile the package and ensure the resulting ``.fap`` is
+   produced.
+
+If any step fails, a concise error is printed and the script exits with a
+non-zero status code, making it suitable for CI environments.  The optional
+``--skip-build`` and ``--skip-lint`` flags can be used to focus on a specific
+stage, and ``--release`` asks ``ufbt`` to build a release package.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, List
+
+
+def parse_args(argv: Iterable[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--skip-lint",
+        action="store_true",
+        help="Skip running 'ufbt lint'.",
+    )
+    parser.add_argument(
+        "--skip-build",
+        action="store_true",
+        help="Skip running 'ufbt build'.",
+    )
+    parser.add_argument(
+        "--release",
+        action="store_true",
+        help="Build release artifacts using 'ufbt build --release'.",
+    )
+    parser.add_argument(
+        "apps",
+        nargs="*",
+        metavar="APP_PATH",
+        help=(
+            "Specific app directories to check. Provide paths like "
+            "'apps/mouse-jiggler/fap'. If omitted, every discovered app is used."
+        ),
+    )
+    return parser.parse_args(list(argv))
+
+
+def discover_apps(explicit_apps: Iterable[str]) -> List[Path]:
+    repo_root = Path(__file__).resolve().parents[1]
+    if explicit_apps:
+        apps = [repo_root / Path(app_path) for app_path in explicit_apps]
+    else:
+        apps = sorted(repo_root.glob("apps/*/fap"))
+
+    filtered = []
+    for app in apps:
+        if not app.exists():
+            raise FileNotFoundError(f"App path does not exist: {app}")
+        if not app.is_dir():
+            raise NotADirectoryError(f"App path is not a directory: {app}")
+        filtered.append(app)
+    if not filtered:
+        raise RuntimeError("No applications discovered. Check the paths supplied.")
+    return filtered
+
+
+def ensure_ufbt_available() -> None:
+    if shutil.which("ufbt") is None:
+        raise SystemExit(
+            "ufbt executable not found. Install it with 'pip install ufbt' or "
+            "activate the repository's venv."
+        )
+
+
+def run_command(command: List[str], *, cwd: Path) -> None:
+    print(f"\n→ {' '.join(command)} (in {cwd})")
+    completed = subprocess.run(command, cwd=cwd, check=False)
+    if completed.returncode != 0:
+        raise subprocess.CalledProcessError(
+            completed.returncode, command, None, None
+        )
+
+
+def run_pipeline(app_dir: Path, *, skip_lint: bool, skip_build: bool, release: bool) -> None:
+    if not skip_lint:
+        run_command(["ufbt", "lint"], cwd=app_dir)
+
+    if not skip_build:
+        cmd = ["ufbt", "build"]
+        if release:
+            cmd.append("--release")
+        run_command(cmd, cwd=app_dir)
+
+
+def main(argv: Iterable[str]) -> int:
+    args = parse_args(argv)
+    ensure_ufbt_available()
+    apps = discover_apps(args.apps)
+
+    print("Discovered apps to test:")
+    for app in apps:
+        print(f"  - {app.relative_to(Path.cwd())}")
+
+    failures: List[tuple[Path, BaseException]] = []
+    for app_dir in apps:
+        print("\n=== Running pipeline for", app_dir.name, "===")
+        try:
+            run_pipeline(
+                app_dir,
+                skip_lint=args.skip_lint,
+                skip_build=args.skip_build,
+                release=args.release,
+            )
+        except BaseException as exc:  # pragma: no cover - defensive programming
+            failures.append((app_dir, exc))
+            print(f"❌ Failure in {app_dir}: {exc}")
+
+    if failures:
+        print("\nSummary: FAIL")
+        for app_dir, exc in failures:
+            print(f"  - {app_dir}: {exc}")
+        return 1
+
+    print("\nSummary: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- add a Python pipeline script that runs `ufbt lint`/`ufbt build` for every app without hardware
- expose the new workflow via `make lint`, `make build-all`, and `make test`
- document the hardware-free pipeline in the README and development guide

## Testing
- `make test` *(fails: ufbt cannot download SDK in the CI sandbox, see log)*

------
https://chatgpt.com/codex/tasks/task_e_68cbf3b866e4832faec6d42a79a2c67e